### PR TITLE
fix: increase retry count and enhance error logging in Anilist client

### DIFF
--- a/src/utils/log_util.ts
+++ b/src/utils/log_util.ts
@@ -130,11 +130,11 @@ export function autoLog(message: string, tag: string = "", level: LogLevel = Log
  * @param tag The tag to log the error under.
  */
 export function autoLogException(e: Error, tag: string = "") {
-    autoLog(e.message, tag, LogLevel.Error, false);
+    autoLog(e.message, tag, LogLevel.Error);
     // Separate stack trace by line breaks, and print each line separately.
     if (e.stack) {
         e.stack.split("\n").forEach((line) => {
-            autoLog(line, tag, LogLevel.Error, false);
+            autoLog(line, tag, LogLevel.Error);
         });
     }
 }


### PR DESCRIPTION
The amount of retry attempts in the Anilist client has been increased from 5 to 7 and the initial delay has been doubled from 250ms to 1s. In addition, more detailed error information is now being logged when a network error occurs during query execution, including the response header and data if any.