### PR TITLE
fix: match Kitsu new domain when loadGlobalAnimeData

### DIFF
--- a/src/types/global_anime_data.ts
+++ b/src/types/global_anime_data.ts
@@ -67,7 +67,7 @@ export namespace GlobalAnimeData {
                     acc["AnimePlanet"] = res[1];
                 } else if ((res = site.match(/anisearch.com\/anime\/(\d+)$/)) && res[1]) {
                     acc["AnimeSearch"] = res[1];
-                } else if ((res = site.match(/kitsu.io\/anime\/(\d+)$/)) && res[1]) {
+                } else if ((res = site.match(/kitsu.(app|io)\/anime\/(\d+)$/)) && res[1]) {
                     acc["Kitsu"] = res[1];
                 } else if ((res = site.match(/livechart.me\/anime\/(\d+)$/)) && res[1]) {
                     acc["LiveChart"] = res[1];


### PR DESCRIPTION
ref: https://github.com/manami-project/anime-offline-database/commit/05ae5c29e4540b70ad0fcc6e5963dfca79fe5093