### PR TITLE
Implement bidirectional sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ npm i
 npm start
 ```
 
+额外的命令行参数：
+
+* `--backward` - 从 Anilist 同步更新回 Bangumi。
+* `--both` - 比较两个平台的更新时间，将较新的条目同步到另一端。
+
 ### Docker 模式
 
 使用如下命令来构建容器并运行：
@@ -95,7 +100,7 @@ npm run token
 
 - [x] Server 模式 (使用 Docker)。
 - [x] Server 模式中的通知推送（在 Docker 中暂时无法使用）。
-- [ ] 从 Anilist 到 bangumi 的双向同步。
+- [x] 从 Anilist 到 bangumi 的双向同步。
 - [ ] 使用 postgres/mongoDB 等数据库作为后端储存。
 
 ## 数据来源

--- a/README_EN.md
+++ b/README_EN.md
@@ -31,6 +31,11 @@ Execute the following commands to run the script in single execution mode:
 npm start
 ```
 
+Additional command line flags:
+
+* `--backward` - Sync changes from Anilist back to Bangumi.
+* `--both` - Detect the newer entry between the two platforms and update the other accordingly.
+
 ### Docker Mode
 
 Run the following commands to build and run the docker image:
@@ -106,7 +111,7 @@ and [sync_util.ts](src/utils/sync_util.ts).
 
 - [x] Server mode (via Docker).
 - [x] Notification push in Server mode (No longer works in Docker mode).
-- [ ] Two-way synchronization from Anilist to bangumi.
+- [x] Two-way synchronization from Anilist to bangumi.
 - [ ] Switch to postgres/mongoDB as backend storage.
 
 ## Data Sources


### PR DESCRIPTION
## Summary
- implement Bangumi client update and convert status
- add bidirectional changelog generation
- support new `--backward` and `--both` flags
- document new flags and mark TODO complete

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848aec56ff8832ea23535cc029d024b