### PR TITLE
fix global anime data

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -7,6 +7,6 @@
   "log_path": "./log/",
   "log_file_level": "info",
   "log_console_level": "info",
-  "global_anime_database_url": "https://raw.githubusercontent.com/manami-project/anime-offline-database/master/anime-offline-database-minified.json",
+  "global_anime_database_url": "https://github.com/manami-project/anime-offline-database/releases/download/latest/anime-offline-database-minified.json",
   "china_anime_database_url": "https://cdn.jsdelivr.net/npm/bangumi-data/dist/data.json"
 }

--- a/src/types/global_anime_data.ts
+++ b/src/types/global_anime_data.ts
@@ -44,6 +44,7 @@ export namespace GlobalAnimeData {
         AniDB = "AniDB",
         AniList = "AniList",
         AnimeCountdown = "AnimeCountdown",
+        AnimeNewsNetwork = "AnimeNewsNetwork",
         AnimePlanet = "AnimePlanet",
         AnimeSearch = "AnimeSearch",
         Kitsu = "Kitsu",
@@ -67,6 +68,8 @@ export namespace GlobalAnimeData {
                     acc["AniList"] = res[1];
                 } else if ((res = site.match(/animecountdown.com\/(\d+)$/)) && res[1]) {
                     acc["AnimeCountdown"] = res[1];
+                } else if ((res = site.match(/animenewsnetwork.com\/encyclopedia\/anime.php\?id=(\d+)$/)) && res[1]) {
+                    acc["AnimeNewsNetwork"] = res[1];
                 } else if ((res = site.match(/anime-planet.com\/anime\/(.+)$/)) && res[1]) {
                     acc["AnimePlanet"] = res[1];
                 } else if ((res = site.match(/anisearch.com\/anime\/(\d+)$/)) && res[1]) {


### PR DESCRIPTION
This pull request updates the anime database URL and adds support for parsing Anime News Network IDs in the global anime data types.

**Configuration update:**

* Changed the `global_anime_database_url` in `config/config.json`, fixed 404 error

**Global anime data enhancements:**

* Added `AnimeNewsNetwork` as a supported site in the `GlobalAnimeData.SiteName` enum in `src/types/global_anime_data.ts`.
* Updated the site ID extraction logic to support parsing Anime News Network URLs and extracting their IDs in `src/types/global_anime_data.ts`.